### PR TITLE
Add validation to the secret env var.

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
+# Secrets: defined in .env.local.
+
 # The NOAA token can be requested here: https://www.ncdc.noaa.gov/cdo-web/token
-# This should be defined in .env.local as a secret.
-# `REACT_APP_NOAA_TOKEN=
+# REACT_APP_NOAA_TOKEN=
+# Open weather token can be generated from https://openweathermap.org/api
+# REACT_APP_OPEN_TOKEN=
+
+# Public variables

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Secrets: defined in .env.local.
 
-# The NOAA token can be requested here: https://www.ncdc.noaa.gov/cdo-web/token
+# The NOAA token, generated from https://www.ncdc.noaa.gov/cdo-web/token
 # REACT_APP_NOAA_TOKEN=
-# Open weather token can be generated from https://openweathermap.org/api
+# Open weather API token, generated from https://openweathermap.org/api
 # REACT_APP_OPEN_TOKEN=
 
 # Public variables

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Using NOAA api to plot weather data over maps
 
 `yarn start`
 
-## 📝 Notes
+## 📝 Environment variables
 
-Requires a .env.local file in the root of the project containing the API tokens. The file should contain these tokens:
-
-NOAA token: https://www.ncdc.noaa.gov/cdo-web/token
-OpenWeather account: https://openweathermap.org/api
+Required secret environment variables, defined in `.env.local`:
+- `REACT_APP_NOAA_TOKEN`: The NOAA token, generated here: https://www.ncdc.noaa.gov/cdo-web/token
+- `REACT_APP_OPEN_TOKEN`: The OpenWeather account token, generated here: https://openweathermap.org/api

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Using NOAA api to plot weather data over maps
 
 Required secret environment variables, defined in `.env.local`:
 - `REACT_APP_NOAA_TOKEN`: The NOAA token, generated here: https://www.ncdc.noaa.gov/cdo-web/token
-- `REACT_APP_OPEN_TOKEN`: The OpenWeather account token, generated here: https://openweathermap.org/api
+- `REACT_APP_OPEN_TOKEN`: The OpenWeather API token, generated here: https://openweathermap.org/api

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,11 @@ import RadarPage from "./RadarPage";
 import WeatherPage from "./WeatherPage";
 
 const NOAA_API_BASE_URL = "/cdo-web/api/v2/locations";
+// TODO: This should not be shipped to the browser.
 const NOAA_TOKEN = process.env.REACT_APP_NOAA_TOKEN;
+if (NOAA_TOKEN == null || NOAA_TOKEN === "") {
+  throw new Error(`'REACT_APP_NOAA_TOKEN' must be defined in .env.local.`);
+}
 
 const fetchRadarData = async () => {
   console.log(`Fetching data from: ${NOAA_API_BASE_URL}`);


### PR DESCRIPTION
- Throws an error if the `REACT_APP_NOAA_TOKEN` token is not defined.
- Change readme to reflect new flags.