### PR TITLE
add client token errors (maintains console errors)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,19 +2,21 @@ import React, { useEffect, useState } from "react";
 import "./App.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
+import LoadingSpinner from "./components/LoadingSpinner";
 import RadarPage from "./RadarPage";
+import ServerError from "./components/ServerError";
 import WeatherPage from "./WeatherPage";
 
 const NOAA_API_BASE_URL = "/cdo-web/api/v2/locations";
 // TODO: This should not be shipped to the browser.
 const NOAA_TOKEN = process.env.REACT_APP_NOAA_TOKEN;
-if (NOAA_TOKEN == null || NOAA_TOKEN === "") {
-  throw new Error(`'REACT_APP_NOAA_TOKEN' must be defined in .env.local.`);
-}
 
 const fetchRadarData = async () => {
   console.log(`Fetching data from: ${NOAA_API_BASE_URL}`);
 
+  if (!NOAA_TOKEN) {
+    throw new Error(`'REACT_APP_NOAA_TOKEN' must be defined in .env.local.`);
+  }
   const response = await fetch(NOAA_API_BASE_URL, {
     headers: {
       token: NOAA_TOKEN,
@@ -25,7 +27,6 @@ const fetchRadarData = async () => {
   }
   if (!response.ok) {
     const text = await response.text();
-    console.error("Error response:", text);
     throw new Error(`HTTP error! Status: ${response.status}, Body: ${text}`);
   }
 
@@ -34,6 +35,7 @@ const fetchRadarData = async () => {
 
 function App() {
   const [radarData, setRadarData] = useState([]);
+  const [error, setError] = useState("");
 
   useEffect(() => {
     let isMounted = true; // track mounting status
@@ -45,7 +47,7 @@ function App() {
           setRadarData(radarData.results);
         }
       } catch (error) {
-        console.error("Error fetching radar data:", error);
+        setError(error.message);
       }
     };
 
@@ -55,13 +57,23 @@ function App() {
       isMounted = false; // cleanup on unmounting
     };
   }, []);
-
   return (
     <Router>
       <Header />
       <div className="App">
         <Routes>
-          <Route path="/" element={<RadarPage data={radarData} />} />
+          <Route
+            path="/"
+            element={
+              error ? (
+                <ServerError errorSource="NOAA" error={error} />
+              ) : radarData?.length ? (
+                <RadarPage data={radarData} />
+              ) : (
+                <LoadingSpinner />
+              )
+            }
+          />
           <Route path="/weather" element={<WeatherPage />} />
         </Routes>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -2,78 +2,16 @@ import React from "react";
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
-import LoadingSpinner from "./components/LoadingSpinner";
 import RadarPage from "./RadarPage";
-import ServerError from "./components/ServerError";
 import WeatherPage from "./WeatherPage";
 
-const NOAA_API_BASE_URL = "/cdo-web/api/v2/locations";
-// TODO: This should not be shipped to the browser.
-const NOAA_TOKEN = process.env.REACT_APP_NOAA_TOKEN;
-
-const fetchRadarData = async () => {
-  console.log(`Fetching data from: ${NOAA_API_BASE_URL}`);
-
-  if (!NOAA_TOKEN) {
-    throw new Error(`'REACT_APP_NOAA_TOKEN' must be defined in .env.local.`);
-  }
-  const response = await fetch(NOAA_API_BASE_URL, {
-    headers: {
-      token: NOAA_TOKEN,
-    },
-  });
-  if (response.redirected) {
-    throw new Error("Request was redirected. Possible authentication issue.");
-  }
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`HTTP error! Status: ${response.status}, Body: ${text}`);
-  }
-
-  return await response.json();
-};
-
 function App() {
-  const [radarData, setRadarData] = useState([]);
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    let isMounted = true; // track mounting status
-
-    const fetchData = async () => {
-      try {
-        const radarData = await fetchRadarData();
-        if (isMounted) {
-          setRadarData(radarData.results);
-        }
-      } catch (error) {
-        setError(error.message);
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      isMounted = false; // cleanup on unmounting
-    };
-  }, []);
   return (
     <Router>
       <Header />
       <div className="App">
         <Routes>
-          <Route
-            path="/"
-            element={
-              error ? (
-                <ServerError errorSource="NOAA" error={error} />
-              ) : radarData?.length ? (
-                <RadarPage data={radarData} />
-              ) : (
-                <LoadingSpinner />
-              )
-            }
-          />
+          <Route path="/" element={<RadarPage />} />
           <Route path="/weather" element={<WeatherPage />} />
         </Routes>
       </div>

--- a/src/components/MapComponent.js
+++ b/src/components/MapComponent.js
@@ -1,21 +1,22 @@
 import React from "react";
 import Map from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
+import ServerError from "./ServerError";
 
 const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
-if (MAPBOX_TOKEN == null || MAPBOX_TOKEN === "") {
-  throw new Error(
-    `'REACT_APP_MAPBOX_ACCESS_TOKEN' must be defined in .env.local.`
-  );
-}
 
 function MapComponent({ initialViewState, mapStyle }) {
-  return (
+  return MAPBOX_TOKEN ? (
     <Map
       mapboxAccessToken={MAPBOX_TOKEN}
       initialViewState={initialViewState}
       style={{ width: 800, height: 600 }}
       mapStyle={mapStyle}
+    />
+  ) : (
+    <ServerError
+      errorSource="MapBox"
+      error="'REACT_APP_MAPBOX_ACCESS_TOKEN' must be defined in .env.local"
     />
   );
 }

--- a/src/components/ServerError.js
+++ b/src/components/ServerError.js
@@ -9,8 +9,8 @@ export default function ServerError({ error, errorSource }) {
   return (
     <section className={styles.container}>
       <h2>
-        Sorry, there was an error fetching the data from
-        {errorSource ? ` ${errorSource}` : ""}.
+        Sorry, there was an error fetching the data
+        {errorSource ? ` from ${errorSource}` : ""}.
       </h2>
       {error ?? <h3>{error}</h3>}
     </section>

--- a/src/components/ServerError.js
+++ b/src/components/ServerError.js
@@ -2,10 +2,17 @@ import React from "react";
 
 import styles from "../styles/ServerError.module.css";
 
-export default function ServerError() {
+export default function ServerError({ error, errorSource }) {
+  if (error) {
+    console.error(error);
+  }
   return (
     <section className={styles.container}>
-      <h2>Sorry, there was an error fetching the data.</h2>
+      <h2>
+        Sorry, there was an error fetching the data from
+        {errorSource ? ` ${errorSource}` : ""}.
+      </h2>
+      {error ?? <h3>{error}</h3>}
     </section>
   );
 }

--- a/src/components/WeatherPanel.js
+++ b/src/components/WeatherPanel.js
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from "react";
 import LoadingSpinner from "./LoadingSpinner";
+import ServerError from "./ServerError";
 
 const NOAA_API_BASE_URL = "/cdo-web/api/v2/locations";
 const NOAA_TOKEN = process.env.REACT_APP_NOAA_TOKEN;
 
 const fetchRadarData = async () => {
+  if (!NOAA_TOKEN) {
+    throw new Error("'REACT_APP_NOAA_TOKEN' must be defined in .env.local");
+  }
   const response = await fetch(NOAA_API_BASE_URL, {
     headers: {
       token: NOAA_TOKEN,
@@ -20,9 +24,10 @@ const fetchRadarData = async () => {
 
 function WeatherPanel() {
   const [radarData, setRadarData] = useState([]);
+  const [error, setError] = useState("");
 
   useEffect(() => {
-    let isMounted = true;
+    let isMounted = true; // track mounting status
 
     const fetchData = async () => {
       try {
@@ -31,33 +36,37 @@ function WeatherPanel() {
           setRadarData(radarData.results);
         }
       } catch (error) {
-        console.error("Error fetching radar data:", error);
+        setError(error.message);
       }
     };
 
     fetchData();
 
     return () => {
-      isMounted = false;
+      isMounted = false; // cleanup on unmounting
     };
   }, []);
 
   return (
     <div>
-      <h2>Radar Data</h2>
-      <p>We've fetched some radar data!</p>
-      {radarData.length ? (
-        <ul>
-          {radarData.map((item) => (
-            <li key={item.id}>
-              <h3>{item.name}</h3>
-              <p>ID: {item.id}</p>
-              <p>Data Coverage: {item.datacoverage}</p>
-              <p>Max Date: {item.maxdate}</p>
-              <p>Min Date: {item.mindate}</p>
-            </li>
-          ))}
-        </ul>
+      {error ? (
+        <ServerError errorSource="NOAA" error={error} />
+      ) : radarData?.length ? (
+        <>
+          <h2>Radar Data</h2>
+          <p>We've fetched some radar data!</p>
+          <ul>
+            {radarData.map((item) => (
+              <li key={item.id}>
+                <h3>{item.name}</h3>
+                <p>ID: {item.id}</p>
+                <p>Data Coverage: {item.datacoverage}</p>
+                <p>Max Date: {item.maxdate}</p>
+                <p>Min Date: {item.mindate}</p>
+              </li>
+            ))}
+          </ul>
+        </>
       ) : (
         <LoadingSpinner />
       )}

--- a/src/contexts/LocationContext.js
+++ b/src/contexts/LocationContext.js
@@ -4,6 +4,7 @@ import LoadingSpinner from "../components/LoadingSpinner";
 import ServerError from "../components/ServerError";
 
 import fetchData from "../helpers/fetchData";
+import Card from "../components/Card";
 
 const defaultLocationContext = { locationData: {}, weatherData: {} };
 
@@ -14,6 +15,7 @@ const OPEN_API_KEY = process.env.REACT_APP_OPEN_TOKEN;
 export const LocationContext = createContext(defaultLocationContext);
 
 export function LocationProvider({ children }) {
+  const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
   const [locationData, setLocationData] = useState(null);
   const [weatherData, setWeatherData] = useState(null);
@@ -21,6 +23,9 @@ export function LocationProvider({ children }) {
   useEffect(() => {
     const fetchAll = async (lat, lon) => {
       try {
+        if (!OPEN_API_KEY) {
+          throw new Error("'REACT_APP_OPEN_TOKEN' must be defined in .env.local")
+        }
         // fetch location data
         await fetchData(
           `${OPEN_API_GEO_URL}?lat=${lat}&lon=${lon}&appid=${OPEN_API_KEY}`,
@@ -34,7 +39,7 @@ export function LocationProvider({ children }) {
           setWeatherData
         );
       } catch (error) {
-        console.log(`Sorry, unable to fetch from OpenWeather because ${error}`);
+        setError(error?.message)
       } finally {
         setLoading(false);
       }
@@ -54,7 +59,9 @@ export function LocationProvider({ children }) {
             {children}
           </LocationContext.Provider>
         ) : (
-          <ServerError />
+          <Card>
+            <ServerError errorSource="OpenWeather" error={error} />
+          </Card>
         )
       ) : (
         <LoadingSpinner />


### PR DESCRIPTION
![image](https://github.com/sammcgrail/radarplot/assets/8960087/26d1db0d-8c9a-4f3a-a3e2-9fd8d7ad9532)
![image](https://github.com/sammcgrail/radarplot/assets/8960087/bc7115a5-c90e-43d7-b729-0cdb7986aae4)
![image](https://github.com/sammcgrail/radarplot/assets/8960087/01c617ad-f701-407f-9e45-5ce04339bb37)
![image](https://github.com/sammcgrail/radarplot/assets/8960087/b64351fa-2c16-4322-b569-2c078842538b)

The way the architecture is right now, each of these had to be done a bit different. Expanded the `<ServerError />`  component to handle logging (stringified, simple) errors to the console.